### PR TITLE
feat: CodeLens navigation commands + bump vscode-languageclient to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "language-1c-bsl",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "language-1c-bsl",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "alignment": "0.0.1",
         "cross-spawn": "^7.0.6",
         "extract-zip": "1.7.0",
-        "fast-xml-parser": "5.7.0",
+        "fast-xml-parser": "5.8.0",
         "filequeue": "^0.5.0",
         "fs-extra": "^10.1.0",
         "glob": "^13.0.2",
@@ -25,7 +25,7 @@
         "request-promise-native": "^1.0.9",
         "semver": "^7.5.2",
         "source-map-support": "^0.5.21",
-        "vscode-languageclient": "^8.1.0",
+        "vscode-languageclient": "^10.0.0",
         "which": "^2.0.2",
         "xml2js": "^0.6.2"
       },
@@ -41,7 +41,7 @@
         "@types/request": "^2.48.8",
         "@types/request-promise-native": "^1.0.18",
         "@types/semver": "^7.3.4",
-        "@types/vscode": "^1.66.0",
+        "@types/vscode": "^1.91.0",
         "@types/which": "^1.3.2",
         "@vscode/test-cli": "^0.0.10",
         "@vscode/test-electron": "^2.4.1",
@@ -52,12 +52,12 @@
         "mocha": "^10.8.2",
         "remap-istanbul": "^0.13.0",
         "should": "^13.2.3",
-        "typescript": "^4.6.3",
+        "typescript": "^5.6.0",
         "typescript-eslint": "^8.34.0",
         "vsce": "^2.7.0"
       },
       "engines": {
-        "vscode": "^1.66.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1168,6 +1168,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -1251,6 +1252,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2505,9 +2507,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
-      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -2517,9 +2519,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5167,9 +5170,9 @@
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5920,9 +5923,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5930,7 +5933,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {
@@ -6246,54 +6249,85 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
+      "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
-      "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0.tgz",
+      "integrity": "sha512-3yRHFkktZQCCg8ehHnD2Z4DZ4mZ17FNo8bxM4OFt8wtpxNBAOZGHmpbIflZSkicvCxi+ozuWntbdeWiY0gP77w==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.3"
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.0",
+        "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.91.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
+      "integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "9.0.0",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
+      "license": "MIT"
+    },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "Programming Languages"
   ],
   "engines": {
-    "vscode": "^1.66.0"
+    "vscode": "^1.91.0"
   },
   "main": "./out/src/extension",
   "scripts": {
@@ -391,7 +391,7 @@
     "@types/request": "^2.48.8",
     "@types/request-promise-native": "^1.0.18",
     "@types/semver": "^7.3.4",
-    "@types/vscode": "^1.66.0",
+    "@types/vscode": "^1.91.0",
     "@types/which": "^1.3.2",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
@@ -402,7 +402,7 @@
     "mocha": "^10.8.2",
     "remap-istanbul": "^0.13.0",
     "should": "^13.2.3",
-    "typescript": "^4.6.3",
+    "typescript": "^5.6.0",
     "typescript-eslint": "^8.34.0",
     "vsce": "^2.7.0"
   },
@@ -410,7 +410,7 @@
     "alignment": "0.0.1",
     "cross-spawn": "^7.0.6",
     "extract-zip": "1.7.0",
-    "fast-xml-parser": "5.7.0",
+    "fast-xml-parser": "5.8.0",
     "filequeue": "^0.5.0",
     "fs-extra": "^10.1.0",
     "glob": "^13.0.2",
@@ -423,7 +423,7 @@
     "request-promise-native": "^1.0.9",
     "semver": "^7.5.2",
     "source-map-support": "^0.5.21",
-    "vscode-languageclient": "^8.1.0",
+    "vscode-languageclient": "^10.0.0",
     "which": "^2.0.2",
     "xml2js": "^0.6.2"
   },

--- a/src/features/languageClientProvider.ts
+++ b/src/features/languageClientProvider.ts
@@ -6,6 +6,8 @@ import {
     Executable,
     LanguageClient,
     LanguageClientOptions,
+    Location as LSLocation,
+    Position as LSPosition,
     ServerOptions
 } from "vscode-languageclient/node";
 import * as which from "which";
@@ -20,6 +22,8 @@ const RESTART_COMMAND = `${LANGUAGE_1C_BSL_CONFIG}.languageServer.restart`;
 const RUN_ALL_TESTS_COMMAND = `${LANGUAGE_1C_BSL_CONFIG}.languageServer.runAllTests`;
 const RUN_TEST_COMMAND = `${LANGUAGE_1C_BSL_CONFIG}.languageServer.runTest`;
 const DEBUG_TEST_COMMAND = `${LANGUAGE_1C_BSL_CONFIG}.languageServer.debugTest`;
+const GOTO_LOCATIONS_COMMAND = `${LANGUAGE_1C_BSL_CONFIG}.languageServer.gotoLocations`;
+const SHOW_REFERENCES_COMMAND = `${LANGUAGE_1C_BSL_CONFIG}.languageServer.showReferences`;
 
 export default class LanguageClientProvider {
     private bslLsReady = false;
@@ -155,7 +159,37 @@ export default class LanguageClientProvider {
                     vscode.commands.executeCommand("workbench.action.debug.start");
                 }
 
-            })
+            }),
+            // Обёртки навигации для CodeLens-линз BSL Language Server. Встроенные команды
+            // редактора ожидают нативные vscode.Uri/Position/Location, а сервер присылает их
+            // сырым JSON (см. microsoft/vscode-languageserver-node#555), поэтому аргументы
+            // оживляются через protocol2CodeConverter перед вызовом встроенной команды.
+            vscode.commands.registerCommand(
+                GOTO_LOCATIONS_COMMAND,
+                async (uri: string, position: LSPosition, locations: LSLocation[], multiple: string) => {
+                    const converter = this.languageClient.protocol2CodeConverter;
+                    await vscode.commands.executeCommand(
+                        "editor.action.goToLocations",
+                        converter.asUri(uri),
+                        converter.asPosition(position),
+                        locations.map(location => converter.asLocation(location)),
+                        multiple ?? "peek",
+                        "Не найдено объявлений"
+                    );
+                }
+            ),
+            vscode.commands.registerCommand(
+                SHOW_REFERENCES_COMMAND,
+                async (uri: string, position: LSPosition, locations: LSLocation[]) => {
+                    const converter = this.languageClient.protocol2CodeConverter;
+                    await vscode.commands.executeCommand(
+                        "editor.action.showReferences",
+                        converter.asUri(uri),
+                        converter.asPosition(position),
+                        locations.map(location => converter.asLocation(location))
+                    );
+                }
+            )
         );
 
         // await this.languageClient.onReady();

--- a/src/features/languageClientProvider.ts
+++ b/src/features/languageClientProvider.ts
@@ -235,7 +235,8 @@ export default class LanguageClientProvider {
                 fileEvents: vscode.workspace.createFileSystemWatcher("**/*.{os,bsl}")
             },
             traceOutputChannel: vscode.window.createOutputChannel(
-                "BSL Language Server Trace Log"
+                "BSL Language Server Trace Log",
+                { log: true }
             )
         };
 

--- a/src/util/serverDownloader.ts
+++ b/src/util/serverDownloader.ts
@@ -25,7 +25,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 //
-import * as extractZipWithCallback from "extract-zip";
+import extractZipWithCallback = require("extract-zip");
 import * as fs from "fs-extra";
 import { jsonDateParser } from "json-date-parser";
 import * as path from "path";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
         "baseUrl": ".",
         "paths": { "*": ["types/*"] },
-		"module": "commonjs",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es6",
 		"outDir": "out",
 		"lib": [


### PR DESCRIPTION
## What

Adds two client-side commands the BSL Language Server targets from its CodeLens lenses, and bumps `vscode-languageclient` to v10.

### CodeLens navigation commands
- `language-1c-bsl.languageServer.gotoLocations`
- `language-1c-bsl.languageServer.showReferences`

The server emits CodeLens whose command should ultimately run the built-in editor commands `editor.action.goToLocations` / `editor.action.showReferences`. Those built-ins cannot be invoked directly with the raw JSON arguments a language server sends (string URI, plain `Position`/`Location` objects) — they require native `vscode` types (see [microsoft/vscode-languageserver-node#555](https://github.com/microsoft/vscode-languageserver-node/issues/555)).

These thin wrappers revive the arguments via the language client's `protocol2CodeConverter` (`asUri`/`asPosition`/`asLocation`) and forward them to the built-in commands. They are registered programmatically (not exposed in the command palette), mirroring the existing test-run commands.

### Bump vscode-languageclient 8.1.0 → 10.0.0
v10 ships an `exports`-only package (no `main`/`types`); the node entry is reachable solely via the `./node` subpath export, which classic module resolution cannot read. Required accompanying changes:
- `tsconfig`: `module`/`moduleResolution` → `node16` (so tsc reads package `exports`; output stays CommonJS — the package has no `"type":"module"`).
- `engines.vscode` `^1.66.0` → `^1.91.0` (v10 requirement); `@types/vscode` to match.
- `typescript` `^4.6` → `^5.6` (node16 resolution + modern `.d.cts` declarations).
- `fast-xml-parser` `5.7.0` → `5.8.0` (5.7.0 shipped a `.d.cts` with a typo that node16 now picks up).
- `traceOutputChannel` now requires `LogOutputChannel` → `createOutputChannel(name, { log: true })`.
- `extract-zip` (`export =`) imported via `import = require` under node16.

## Why
Server-side support lives in [1c-syntax/bsl-language-server#4017](https://github.com/1c-syntax/bsl-language-server/issues/4017) (bidirectional DI CodeLens for the «Autumn» framework). The server picks the command id per client: VS Code and compatible editors (VS Code, Cursor, Antigravity, code-server) get these wrapper commands; other clients (e.g. LSP4IJ) get the standard editor commands.

## Verified
End-to-end in code-server: a CodeLens over an injection point (`&Пластилин`) navigates to the producer's constructor on click — the wrapper converts the arguments and the built-in `editor.action.goToLocations` jumps to the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)