### PR TITLE
chore: release 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.34.0
+
+* Добавлены команды навигации CodeLens (`gotoLocations` / `showReferences`)
+* Обновление vscode-languageclient до версии 10
+
 ## 1.33.2
 
 * Добавлена подсветка синтаксиса для директивы `#stack` (`keyword.control.stack.bsl`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "language-1c-bsl",
-  "version": "1.33.2",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "language-1c-bsl",
-      "version": "1.33.2",
+      "version": "1.34.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "alignment": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Language 1C (BSL)",
   "description": "Syntax highlighting for 1C:Enterprise 8.",
   "icon": "images/1c-syntax.png",
-  "version": "1.33.2",
+  "version": "1.34.0",
   "publisher": "1c-syntax",
   "galleryBanner": {
     "color": "#0000FF",


### PR DESCRIPTION
Минорный релиз 1.34.0.

## Изменения версии
- `package.json`: 1.33.2 → 1.34.0
- `package-lock.json`: оба поля version → 1.34.0
- `CHANGELOG.md`: добавлена секция `## 1.34.0`

## Содержимое релиза (изменения с v1.33.2)
* Добавлены команды навигации CodeLens (`gotoLocations` / `showReferences`)
* Обновление vscode-languageclient до версии 10

После мержа можно создать GitHub Release `v1.34.0`, что запустит публикацию в VSCode Marketplace / Open VSX.

https://claude.ai/code/session_01Aof1z4T43AyrLDcirzz5P4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aof1z4T43AyrLDcirzz5P4)_