### PR TITLE
Добавлена настройка languageServerJavaOpts для параметров JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.35.0
+
+* Добавлена настройка `language-1c-bsl.languageServerJavaOpts` для передачи параметров JVM. Значение добавляется к системной переменной `_JAVA_OPTIONS` и применяется как при запуске BSL Language Server из zip-инсталляции, так и из jar-инсталляции. Настройка заменяет `language-1c-bsl.languageServerExternalJarJavaOpts`
+
 ## 1.34.0
 
 * Добавлены команды навигации CodeLens (`gotoLocations` / `showReferences`)

--- a/package.json
+++ b/package.json
@@ -266,12 +266,10 @@
           "type": "string",
           "default": "java"
         },
-        "language-1c-bsl.languageServerExternalJarJavaOpts": {
-          "description": "Additional java options.",
-          "type": "array",
-          "default": [
-            "-Xmx2g"
-          ]
+        "language-1c-bsl.languageServerJavaOpts": {
+          "description": "Additional JVM options for BSL Language Server. Specified as a string and appended to the system _JAVA_OPTIONS environment variable. Applied both to zip-installed and external jar BSL Language Server.",
+          "type": "string",
+          "default": "-Xmx2g"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
         "language-1c-bsl.languageServerJavaOpts": {
           "description": "Additional JVM options for BSL Language Server. Specified as a string and appended to the system _JAVA_OPTIONS environment variable. Applied both to zip-installed and external jar BSL Language Server.",
           "type": "string",
-          "default": "-Xmx2g"
+          "default": "-Xmx4g"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Language 1C (BSL)",
   "description": "Syntax highlighting for 1C:Enterprise 8.",
   "icon": "images/1c-syntax.png",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "publisher": "1c-syntax",
   "galleryBanner": {
     "color": "#0000FF",

--- a/src/features/languageClientProvider.ts
+++ b/src/features/languageClientProvider.ts
@@ -274,10 +274,7 @@ export default class LanguageClientProvider {
             languageServerPath = `"${languageServerPath}"`;
         }
 
-        const javaOpts: string[] = configuration.get("languageServerExternalJarJavaOpts");
-
         const args: string[] = [];
-        args.push(...javaOpts);
         args.push("-jar", languageServerPath);
 
         const configurationFile = await this.getConfigurationFile(configuration);
@@ -288,7 +285,7 @@ export default class LanguageClientProvider {
         return {
             command,
             args,
-            options: { env: process.env, shell: true }
+            options: { env: this.getEnvWithJavaOpts(configuration), shell: true }
         };
     }
 
@@ -308,8 +305,18 @@ export default class LanguageClientProvider {
         return {
             command,
             args,
-            options: { env: process.env, shell: true }
+            options: { env: this.getEnvWithJavaOpts(configuration), shell: true }
         };
+    }
+
+    private getEnvWithJavaOpts(configuration: vscode.WorkspaceConfiguration): NodeJS.ProcessEnv {
+        const javaOpts = String(configuration.get("languageServerJavaOpts") ?? "").trim();
+        const env = { ...process.env };
+        if (javaOpts) {
+            const existingOpts = env._JAVA_OPTIONS ? `${env._JAVA_OPTIONS} ` : "";
+            env._JAVA_OPTIONS = `${existingOpts}${javaOpts}`;
+        }
+        return env;
     }
 
     private async getConfigurationFile(configuration: vscode.WorkspaceConfiguration): Promise<string | undefined> {


### PR DESCRIPTION
## Описание

Добавлена новая настройка `language-1c-bsl.languageServerJavaOpts`, которая заменяет существующую `language-1c-bsl.languageServerExternalJarJavaOpts`.

Пользователь указывает параметры JVM в виде строки. Эти параметры добавляются к системной переменной `_JAVA_OPTIONS` и передаются как переменная среды `_JAVA_OPTIONS` при запуске BSL Language Server — **как из zip-инсталляции** (нативный бинарник), **так и из jar-инсталляции**.

## Изменения

- **`package.json`**: настройка `languageServerExternalJarJavaOpts` (тип `array`) заменена на `languageServerJavaOpts` (тип `string`, значение по умолчанию `-Xmx4g`).
- **`src/features/languageClientProvider.ts`**:
  - Добавлен helper `getEnvWithJavaOpts()`, который копирует `process.env` и дописывает значение настройки к существующей `_JAVA_OPTIONS` (через пробел, если она уже задана).
  - `getExecutableJar` (jar) больше не передаёт java-опции через аргументы командной строки — теперь они идут через `_JAVA_OPTIONS`.
  - `getExecutableBinary` (zip) теперь тоже получает java-опции через `_JAVA_OPTIONS` (раньше они вообще не применялись).
- Версия поднята до `1.35.0`, обновлён `CHANGELOG.md`.

https://claude.ai/code/session_015EJLM3GVuSwJumefLnotvK

---
_Generated by [Claude Code](https://claude.ai/code/session_015EJLM3GVuSwJumefLnotvK)_