### PR TITLE
Добавлена возможность запуска MCP-сервера BSL Language Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Добавлена настройка `language-1c-bsl.languageServerMcpEnabled` (по умолчанию `false`) для запуска BSL Language Server с MCP-сервером (Streamable HTTP) параллельно с LSP. При включении BSL LS запускается с флагом `--mcp`, MCP-эндпоинт доступен по адресу `http://localhost:<port>/mcp`. Порт задаётся отдельно настройкой `language-1c-bsl.languageServerMcpPort` (обязательна при включённом MCP; если пусто — MCP не поднимается, выводится warning, LSP работает штатно). Для исключения конфликтов при нескольких экземплярах VS Code задавайте уникальный порт per workspace. См. [McpMode.md](McpMode.md).
+
 ## 2.0.0
 
 * Настройка `language-1c-bsl.contextSystemEnabled` по умолчанию выключена (`false`) — по умолчанию все языковые возможности обеспечивает BSL Language Server. Внутреннюю систему контекста плагина можно включить вручную (например, при работе с выключенным BSL Language Server)

--- a/package.json
+++ b/package.json
@@ -270,6 +270,16 @@
           "description": "Additional JVM options for BSL Language Server. Specified as a string and appended to the system _JAVA_OPTIONS environment variable. Applied both to zip-installed and external jar BSL Language Server.",
           "type": "string",
           "default": "-Xmx4g"
+        },
+        "language-1c-bsl.languageServerMcpEnabled": {
+          "description": "Run BSL Language Server with MCP server (Streamable HTTP) alongside LSP. Requires explicit port (see languageServerMcpPort). When enabled, BSL LS is started with --mcp flag and MCP endpoint becomes available at http://localhost:<port>/mcp.",
+          "type": "boolean",
+          "default": false
+        },
+        "language-1c-bsl.languageServerMcpPort": {
+          "description": "Port for BSL Language Server MCP endpoint (Streamable HTTP). Required when languageServerMcpEnabled is true. If empty when MCP is enabled, a warning is shown and BSL LS starts without MCP. To avoid conflicts across multiple VS Code instances, set a distinct port per workspace.",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/src/features/languageClientProvider.ts
+++ b/src/features/languageClientProvider.ts
@@ -285,6 +285,8 @@ export default class LanguageClientProvider {
             args.push("-c", configurationFile);
         }
 
+        args.push(...this.getMcpArgs(configuration));
+
         return {
             command,
             args,
@@ -304,6 +306,8 @@ export default class LanguageClientProvider {
         if (configurationFile) {
             args.push("-c", configurationFile);
         }
+
+        args.push(...this.getMcpArgs(configuration));
 
         return {
             command,
@@ -344,6 +348,23 @@ export default class LanguageClientProvider {
         }
 
         return configurationFile;
+    }
+
+    private getMcpArgs(configuration: vscode.WorkspaceConfiguration): string[] {
+        const mcpEnabled = Boolean(configuration.get("languageServerMcpEnabled"));
+        if (!mcpEnabled) {
+            return [];
+        }
+
+        const port = String(configuration.get("languageServerMcpPort") ?? "").trim();
+        if (!port) {
+            const message = "BSL Language Server: MCP is enabled but port is empty (language-1c-bsl.languageServerMcpPort). MCP will not be started.";
+            console.warn(message);
+            void vscode.window.showWarningMessage(message);
+            return [];
+        }
+
+        return ["--mcp", `--server.port=${port}`];
     }
 
     private getBinaryName(langServerInstallDir: string) {


### PR DESCRIPTION
Добавлены настройки languageServerMcpEnabled (по умолчанию выключен) и languageServerMcpPort (по умолчанию пустой). При включении BSL LS запускается с флагом --mcp, MCP-эндпоинт поднимается по Streamable HTTP на заданном порту. Если порт не задан — выводится warning, LS работает без MCP. Порт задаёт пользователь per workspace для исключения конфликтов при нескольких экземплярах VS Code.