### PR TITLE
feat: подсветка вложенных аннотаций как значений параметров аннотаций

### DIFF
--- a/syntaxes/1c.tmLanguage.json
+++ b/syntaxes/1c.tmLanguage.json
@@ -491,6 +491,9 @@
           },
           "patterns": [
             {
+              "include": "#annotations"
+            },
+            {
               "include": "#basic"
             },
             {


### PR DESCRIPTION
## Что и зачем

В OneScript 2.0.0 значением параметра аннотации может быть другая аннотация (вложенные аннотации), например:

```bsl
&Пластилин(&Деталька("ИмяАппендера")) Аппендер
```

TextMate-грамматика этого не учитывала: блок параметров аннотации не рекурсировал в `#annotations`, из-за чего первый `)` (закрывающий вложенную `&Деталька(...)`) закрывал внешнюю аннотацию раньше времени, а имя вложенной аннотации не получало скоуп `storage.type.annotation.bsl`.

## Изменение

В правило «Annotations with parameters» (`syntaxes/1c.tmLanguage.json`) добавлен `{ "include": "#annotations" }` первым паттерном блока параметров. Вложенная аннотация разбирается рекурсивно, её скобки балансируются, внешняя аннотация закрывается вовремя.

## Проверка

Прогон TextMate-тестов требует соответствующего тулинга и в этом окружении не запускался. Логика идентична уже принятому решению в Lezer-грамматике `codemirror-lang-bsl` и разбору в `bsl-parser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Knr8gmzxGCTqmbLhYXUEue)_